### PR TITLE
Fix README heading position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Rastreador de Veículos (Desktop - Python + OpenStreetMap)
 
 Este é um aplicativo desktop feito em Python para rastrear veículos em tempo real, usando **links de localização enviados pelo WhatsApp** e exibindo tudo em um **mapa interativo gratuito (OpenStreetMap via Folium)**.


### PR DESCRIPTION
## Summary
- remove stray leading newline from README

## Testing
- `python -m py_compile rastreador.py`

------
https://chatgpt.com/codex/tasks/task_e_68481dd2ded8832bb4cc00762f00aa35