### PR TITLE
Fix map load using QUrl

### DIFF
--- a/rastreador.py
+++ b/rastreador.py
@@ -29,7 +29,9 @@ class MapaRastreamento(QWidget):
 
         self.map = folium.Map(location=[-15.7797, -47.9297], zoom_start=4)
         self.salvar_mapa()
-        self.view.load(f"file://{os.path.abspath(MAP_FILE)}")
+        # QWebEngineView.load espera um QUrl. Usar uma string causa erro em tempo de execução
+        # em alguns ambientes. Por isso carregamos o arquivo através de QUrl.fromLocalFile
+        self.view.load(QUrl.fromLocalFile(os.path.abspath(MAP_FILE)))
 
         layout.addWidget(self.input_link)
         layout.addWidget(self.input_nome)


### PR DESCRIPTION
## Summary
- ensure that QWebEngineView loads the map using a QUrl instead of a plain string

## Testing
- `python -m py_compile rastreador.py`


------
https://chatgpt.com/codex/tasks/task_e_68481bd00f74832ba1d4017f8a35690b